### PR TITLE
add option to update indirect dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Timezone defined https://momentjs.com/timezone/ used to verify if the current ti
 
 Defines what dependencies should be deployed. Either `dev` or `all`. Default `dev`
 
+#### updateIndirectDependencies
+
+Defines whether to deploy indirect dependencies (dependencies of dependencies). Either `true` or `false`. Default `false`
+
 ### Development
 
 To install all dependencies run:

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Defines what dependencies should be deployed. Either `dev` or `all`. Default `dev`'
     required: false
     default: dev
+  updateIndirectDependencies:
+    description: 'Defines whether to update dependencies of dependencies. Either `true` or `false`. Default `false`'
+    required: false
+    default: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ const DEPENDABOT_LABEL = 'dependencies';
 
 const getInputParams = (): InputParams => {
   const deployDependencies = core.getInput('deployDependencies') as DeployDependencies;
+  const updateIndirectDependencies = Boolean(core.getInput('updateIndirectDependencies'));
   const gitHubToken = core.getInput('gitHubToken');
   const deployOnlyInWorkingHours = Boolean(core.getInput('deployOnlyInWorkingHours'));
   const timezone = core.getInput('timezone');
@@ -48,6 +49,7 @@ const getInputParams = (): InputParams => {
 
   return {
     deployDependencies,
+    updateIndirectDependencies,
     gitHubToken,
     maxDeployVersion,
     deployOnlyInWorkingHours,
@@ -184,7 +186,7 @@ const run = async (payload: WebhookPayloadStatus): Promise<void> => {
     return;
   }
 
-  if (!isInAnyDependencies(packageName)) {
+  if (!input.updateIndirectDependencies && !isInAnyDependencies(packageName)) {
     console.log(`Skipping deploy. Package ${packageName} not found in any dependencies`);
     return;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type DeployDependencies = 'dev' | 'all';
 
 export interface InputParams {
   deployDependencies: DeployDependencies;
+  updateIndirectDependencies: boolean;
   gitHubToken: string;
   maxDeployVersion: VersionType;
   deployOnlyInWorkingHours: boolean;


### PR DESCRIPTION
Adds additional argument `updateIndirectDependencies` which controls whether indirect dependencies are also deployed.
Most of our tribe's Dependabot PRs are for indirect dependencies not for direct ones. 